### PR TITLE
Add Fraction Parsing Support to Ingredient Parser

### DIFF
--- a/test/core/services/ingredient_parser_service_test.dart
+++ b/test/core/services/ingredient_parser_service_test.dart
@@ -252,6 +252,251 @@ void main() {
       });
     });
 
+    group('Fraction Edge Cases', () {
+      test('handles fraction greater than 1: 5/3', () {
+        final result = parserService.parseIngredientLine('5/3 xícara de farinha');
+        expect(result.quantity, closeTo(1.667, 0.001));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('handles fraction without unit', () {
+        final result = parserService.parseIngredientLine('1/2 mangas');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('piece'));
+      });
+
+      test('handles fraction without space before ingredient', () {
+        final result = parserService.parseIngredientLine('½mangas');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('piece'));
+      });
+
+      test('handles mixed number without unit', () {
+        final result = parserService.parseIngredientLine('2 1/2 ovos');
+        expect(result.quantity, equals(2.5));
+        expect(result.unit, equals('piece'));
+      });
+
+      test('handles very large fraction', () {
+        final result = parserService.parseIngredientLine('10/3 kg de tomates');
+        expect(result.quantity, closeTo(3.333, 0.001));
+        expect(result.unit, equals('kg'));
+      });
+
+      test('handles unicode fraction at start of line', () {
+        final result = parserService.parseIngredientLine('⅛colher de chá de pimenta');
+        expect(result.quantity, equals(0.125));
+        expect(result.unit, equals('tsp'));
+      });
+
+      test('handles mixed number with large whole part', () {
+        final result = parserService.parseIngredientLine('25 1/2 kg de farinha');
+        expect(result.quantity, equals(25.5));
+        expect(result.unit, equals('kg'));
+      });
+
+      test('verifies backward compatibility with decimals', () {
+        final result = parserService.parseIngredientLine('1.5 xícara de açúcar');
+        expect(result.quantity, equals(1.5));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('verifies backward compatibility with integers', () {
+        final result = parserService.parseIngredientLine('3 kg de carne');
+        expect(result.quantity, equals(3.0));
+        expect(result.unit, equals('kg'));
+      });
+    });
+
+    group('Unicode Fraction Parsing', () {
+      test('parses: ½ xícara de farinha', () {
+        final result = parserService.parseIngredientLine('½ xícara de farinha');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: ¼ colher de sopa de azeite', () {
+        final result = parserService.parseIngredientLine('¼ colher de sopa de azeite');
+        expect(result.quantity, equals(0.25));
+        expect(result.unit, equals('tbsp'));
+        expect(result.ingredientName, equals('azeite'));
+      });
+
+      test('parses: ¾ kg de mangas', () {
+        final result = parserService.parseIngredientLine('¾ kg de mangas');
+        expect(result.quantity, equals(0.75));
+        expect(result.unit, equals('kg'));
+        expect(result.ingredientName, equals('mangas'));
+      });
+
+      test('parses: ⅓ xícara de açúcar', () {
+        final result = parserService.parseIngredientLine('⅓ xícara de açúcar');
+        expect(result.quantity, closeTo(0.333, 0.001));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: ⅔ colher de chá de sal', () {
+        final result = parserService.parseIngredientLine('⅔ colher de chá de sal');
+        expect(result.quantity, closeTo(0.667, 0.001));
+        expect(result.unit, equals('tsp'));
+        expect(result.ingredientName, equals('sal'));
+      });
+
+      test('parses: ⅛ colher de chá de canela', () {
+        final result = parserService.parseIngredientLine('⅛ colher de chá de canela');
+        expect(result.quantity, equals(0.125));
+        expect(result.unit, equals('tsp'));
+      });
+
+      test('parses: ⅞ xícara de leite', () {
+        final result = parserService.parseIngredientLine('⅞ xícara de leite');
+        expect(result.quantity, equals(0.875));
+        expect(result.unit, equals('cup'));
+      });
+    });
+
+    group('Slash Fraction Parsing', () {
+      test('parses: 1/2 xícara de farinha', () {
+        final result = parserService.parseIngredientLine('1/2 xícara de farinha');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: 3/4 colher de sopa de mel', () {
+        final result = parserService.parseIngredientLine('3/4 colher de sopa de mel');
+        expect(result.quantity, equals(0.75));
+        expect(result.unit, equals('tbsp'));
+      });
+
+      test('parses: 1/4 kg de açúcar', () {
+        final result = parserService.parseIngredientLine('1/4 kg de açúcar');
+        expect(result.quantity, equals(0.25));
+        expect(result.unit, equals('kg'));
+      });
+
+      test('parses: 2/3 xícara de leite', () {
+        final result = parserService.parseIngredientLine('2/3 xícara de leite');
+        expect(result.quantity, closeTo(0.667, 0.001));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: 1/3 colher de chá de canela', () {
+        final result = parserService.parseIngredientLine('1/3 colher de chá de canela');
+        expect(result.quantity, closeTo(0.333, 0.001));
+        expect(result.unit, equals('tsp'));
+      });
+
+      test('parses: 5/4 xícara de farinha (fraction > 1)', () {
+        final result = parserService.parseIngredientLine('5/4 xícara de farinha');
+        expect(result.quantity, equals(1.25));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('handles invalid fraction: 1/0 (divide by zero)', () {
+        final result = parserService.parseIngredientLine('1/0 xícara de farinha');
+        expect(result.quantity, equals(1.0)); // Falls back to default
+        expect(result.unit, equals('cup'));
+      });
+    });
+
+    group('Mixed Number Parsing', () {
+      test('parses: 2 1/2 kg de mangas', () {
+        final result = parserService.parseIngredientLine('2 1/2 kg de mangas');
+        expect(result.quantity, equals(2.5));
+        expect(result.unit, equals('kg'));
+        expect(result.ingredientName, equals('mangas'));
+      });
+
+      test('parses: 1 ½ xícara de açúcar', () {
+        final result = parserService.parseIngredientLine('1 ½ xícara de açúcar');
+        expect(result.quantity, equals(1.5));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: 1 1/4 colheres de sopa de azeite', () {
+        final result = parserService.parseIngredientLine('1 1/4 colheres de sopa de azeite');
+        expect(result.quantity, equals(1.25));
+        expect(result.unit, equals('tbsp'));
+        expect(result.ingredientName, equals('azeite'));
+      });
+
+      test('parses: 3 3/4 xícaras de farinha', () {
+        final result = parserService.parseIngredientLine('3 3/4 xícaras de farinha');
+        expect(result.quantity, equals(3.75));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: 2 ⅔ kg de tomates', () {
+        final result = parserService.parseIngredientLine('2 ⅔ kg de tomates');
+        expect(result.quantity, closeTo(2.667, 0.001));
+        expect(result.unit, equals('kg'));
+      });
+
+      test('parses: 5 1/3 colheres de chá de canela', () {
+        final result = parserService.parseIngredientLine('5 1/3 colheres de chá de canela');
+        expect(result.quantity, closeTo(5.333, 0.001));
+        expect(result.unit, equals('tsp'));
+      });
+
+      test('parses: 10 ¼ xícaras de leite', () {
+        final result = parserService.parseIngredientLine('10 ¼ xícaras de leite');
+        expect(result.quantity, equals(10.25));
+        expect(result.unit, equals('cup'));
+      });
+    });
+
+    group('Portuguese "de" with Fractions', () {
+      test('parses: 1/4 de xícara de farinha', () {
+        final result = parserService.parseIngredientLine('1/4 de xícara de farinha');
+        expect(result.quantity, equals(0.25));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('parses: 1/3 de colher de chá de sal', () {
+        final result = parserService.parseIngredientLine('1/3 de colher de chá de sal');
+        expect(result.quantity, closeTo(0.333, 0.001));
+        expect(result.unit, equals('tsp'));
+        expect(result.ingredientName, equals('sal'));
+      });
+
+      test('parses: ½ de xícara de azeite', () {
+        final result = parserService.parseIngredientLine('½ de xícara de azeite');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('cup'));
+        expect(result.ingredientName, equals('azeite'));
+      });
+
+      test('parses: 1 1/2 de colheres de sopa de mel', () {
+        final result = parserService.parseIngredientLine('1 1/2 de colheres de sopa de mel');
+        expect(result.quantity, equals(1.5));
+        expect(result.unit, equals('tbsp'));
+      });
+
+      test('parses: ¾ de colher de chá de canela', () {
+        final result = parserService.parseIngredientLine('¾ de colher de chá de canela');
+        expect(result.quantity, equals(0.75));
+        expect(result.unit, equals('tsp'));
+      });
+
+      test('parses: 2/3 de xícara de leite', () {
+        final result = parserService.parseIngredientLine('2/3 de xícara de leite');
+        expect(result.quantity, closeTo(0.667, 0.001));
+        expect(result.unit, equals('cup'));
+      });
+
+      test('verifies compound units still work: 1/2 colher de sopa de mel', () {
+        final result = parserService.parseIngredientLine('1/2 colher de sopa de mel');
+        expect(result.quantity, equals(0.5));
+        expect(result.unit, equals('tbsp'));
+      });
+
+      test('verifies mixed numbers with compound units: 1 1/2 colheres de chá de canela', () {
+        final result = parserService.parseIngredientLine('1 1/2 colheres de chá de canela');
+        expect(result.quantity, equals(1.5));
+        expect(result.unit, equals('tsp'));
+      });
+    });
+
     group('Localization Support', () {
       test('recognizes Portuguese unit names', () {
         final result = parserService.parseIngredientLine('2 xícaras de farinha');


### PR DESCRIPTION
## Summary

Adds comprehensive fraction parsing support to the ingredient parser, enabling users to paste recipes with fractions directly without manual conversion. This resolves a critical UX friction point in the bulk recipe update workflow.

## Changes

### Core Functionality
- **Unicode fractions**: Recognizes 15 unicode fractions (½, ⅓, ¼, ⅔, ¾, ⅕, ⅖, ⅗, ⅘, ⅙, ⅚, ⅛, ⅜, ⅝, ⅞)
- **Slash fractions**: Parses any valid slash fraction (1/2, 3/4, 5/4, etc.)
- **Mixed numbers**: Handles mixed numbers with both unicode and slash fractions (2 1/2, 1 ½, etc.)
- **Portuguese "de" patterns**: Correctly handles "de" between fractions and units ("1/4 de xícara")

### Implementation Details

**New Methods:**
- `_parseQuantity()`: Detects and parses mixed numbers, delegates to `_parseFraction()`
- `_parseFraction()`: Converts unicode/slash fractions to decimal values

**Enhanced Logic:**
- Updated quantity regex to match all fraction formats
- Portuguese "de" stripping before unit matching for patterns like "1/4 de xícara"
- Graceful error handling for invalid fractions (divide by zero returns 1.0)
- Maintains backward compatibility with integers and decimals

### Documentation
- Comprehensive docstrings with examples for all new methods
- Inline comments explaining complex fraction parsing logic
- Updated `parseIngredientLine()` docstring with full format support

### Testing
- **38 new test cases** covering all fraction patterns
- **5 test groups**: Unicode fractions, slash fractions, mixed numbers, Portuguese "de" patterns, edge cases
- **All 68 tests passing** (30 original + 38 new)
- **No regressions** detected
- **Edge cases covered**: Fractions > 1, divide by zero, missing units, large numbers

## Examples

```dart
// Before: Failed to parse
"1/2 xícara de farinha" → ❌ Parse error

// After: Works perfectly
"1/2 xícara de farinha" → ✅ qty: 0.5, unit: "cup", name: "farinha"
"½ colher de sopa de azeite" → ✅ qty: 0.5, unit: "tbsp", name: "azeite"
"2 1/2 kg de mangas" → ✅ qty: 2.5, unit: "kg", name: "mangas"
"1/4 de xícara de leite" → ✅ qty: 0.25, unit: "cup", name: "leite"
```

## Testing

✅ `flutter analyze` - No issues found
✅ `flutter test` - All 68 tests passing
✅ Manual testing in app - Verified with real recipes

## Impact

- **Eliminates manual fraction conversion** when pasting recipes
- **Improves bulk recipe update UX** (#155)
- **Supports Portuguese recipe patterns** common in Brazilian cooking
- **Maintains backward compatibility** with existing ingredient parsing

## Related Issues

Closes #195

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>